### PR TITLE
Allow variables in $ScriptBlock

### DIFF
--- a/Public/Invoke-AsCurrentUser.ps1
+++ b/Public/Invoke-AsCurrentUser.ps1
@@ -16,7 +16,8 @@ function Invoke-AsCurrentUser {
     if (!("RunAsUser.ProcessExtensions" -as [type])) {
         Add-Type -TypeDefinition $script:source -Language CSharp
     }
-    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($ScriptBlock))
+    $ExpandedScriptBlock = $ExecutionContext.InvokeCommand.ExpandString($ScriptBlock)
+    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($ExpandedScriptBlock))
     $privs = whoami /priv /fo csv | ConvertFrom-Csv | Where-Object { $_.'Privilege Name' -eq 'SeDelegateSessionUserImpersonatePrivilege' }
     if ($privs.State -eq "Disabled") {
         Write-Error -Message "Not running with correct privilege. You must run this script as system or have the SeDelegateSessionUserImpersonatePrivilege token."


### PR DESCRIPTION
Uses $ExecutionContext.InvokeCommand.ExpandString to expand the $ScriptBlock to evaluate the variables from the calling script/function

Fixes https://github.com/KelvinTegelaar/RunAsUser/issues/7

There are security considerations when using this method. Since we are expanding the commands into a less privileged context, I  think the risks are quite minimal to non-existent. An alternative would be to output and read back the commands as a temporary file but that has even more security implications (permissions of the files, race condition of the file being written vs read).

I've tested with a one line $ScriptBlock and three line $ScriptBlock.